### PR TITLE
Proposed changes for using old bash version and ubuntu 16.04

### DIFF
--- a/devkit/apply-state.sh
+++ b/devkit/apply-state.sh
@@ -64,22 +64,36 @@ else
     goroot=NONE
 fi
 
-declare -A grains
-grains[realuser]="$(id -un ${SUDO_UID})"
-grains[realgroup]="$(id -gn ${SUDO_UID})"
-grains[homedir]="$(eval echo ~$(id -un ${SUDO_UID}))"
-grains[stateroot]="${saltdir}/states"
-grains[saltenv]=dev
-grains[docker]="${docker}"
-grains[gopath]="${gopath}"
-grains[goroot]="${goroot}"
+# associative arrays not available in bash before version 4
+# thus reverting from associative array to two parallel arrays
+grain_names=(
+realuser
+realgroup
+homedir
+stateroot
+saltenv
+docker
+gopath
+goroot
+)
+
+grain_values=(
+"$(id -un ${SUDO_UID})"
+"$(id -gn ${SUDO_UID})"
+"$(eval echo ~$(id -un ${SUDO_UID}))"
+"${saltdir}/states"
+dev
+"${docker}"
+"${gopath}"
+"${goroot}"
+)
 
 echo Configuring grains for the development kit salt states
 
-for key in "${!grains[@]}"; do
+for i in ${!grain_names[@]}; do
     salt-call \
         --config-dir "${saltdir}/config/" \
-        grains.setval ${key} "${grains[${key}]}"
+        grains.setval "${grain_names[$i]}" "${grain_values[$i]}"
 done
 
 echo

--- a/devkit/states/base/init.sls
+++ b/devkit/states/base/init.sls
@@ -2,6 +2,27 @@
 
 {% set installs = grains.cfg_base.installs %}
 
+{#
+We get the following error on ubuntu 16.04:
+    UnicodeDecodeError: 'utf8' codec can't decode byte 0xbd in position 21: invalid start byte
+The following LANG settings fixes this problen in a docker container:
+    docker run -e LANG=C.UTF-8 -e LC_ALL=C.UTF-8 -it -v $(pwd):/vol xenial:salted bash
+So the preference is to set the locale in our base install state
+Copied below from https://docs.saltstack.com/en/latest/ref/states/all/salt.states.locale.html
+Possible only set the locale for specific OSes like ubuntu 16.04
+This has not been tested
+#}
+
+us_locale:
+  locale.present:
+    - name: en_US.UTF-8
+
+default_locale:
+  locale.system:
+    - name: en_US.UTF-8
+    - require:
+      - locale: us_locale
+
 {% if installs and 'firefox' in installs %}
 firefox:
   {% if grains.os_family == 'MacOS' %}

--- a/devkit/states/pretty-swag/init.sls
+++ b/devkit/states/pretty-swag/init.sls
@@ -1,10 +1,32 @@
 # Install prettyswag
 
+{#
+pretty-swag will not run on ubuntu 16.04
+We get the following error with "pretty-swag -v"
+    /usr/local/lib/node_modules/pretty-swag/pretty-swag.js:119
+    let sep = context.items.enum.length < 4 ? "," : ",\n";
+    ^^^
+    SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside
+So maybe we need to check the nodejs version before trying to install pretty-swag
+#}
+
 {% set installs = grains.cfg_pretty_swag.installs %}
 
 {% if installs and 'pretty_swag' in installs %}
   {% set pretty_swag_pkg_name = 'pretty-swag' %}
   
+nodejs-installed:
+  pkg.installed:
+    - name: nodejs
+  {# pretty-swag expects a "node" binary #}
+  {% if not grains.os_family == 'MacOS' %}
+  file.symlink:
+    - onlyif:   test -x /usr/bin/nodejs
+    - unless:   test -x /usr/bin/node
+    - name:     /usr/bin/node
+    - target:   /usr/bin/nodejs
+  {% endif %}
+
 npm-installed:
   pkg.installed:
     - name: npm
@@ -13,6 +35,7 @@ pretty-swag-installed:
   npm.installed:
     - name:       {{ pretty_swag_pkg_name }}
     - require:
+      - pkg:      nodejs
       - pkg:      npm
 
   {% if grains.cfg_pretty_swag.debug.enable %}


### PR DESCRIPTION
Only the bash change to apply-state.sh has been tested. This fixes the MacOS bootstrap.

See the comments in the other two files for xenial problem descriptions and proposed solutions.