### PR TITLE
Prevent pretty-swag install on xenial. Fix us_locale state conflict.

### DIFF
--- a/devkit/states/base/init.sls
+++ b/devkit/states/base/init.sls
@@ -2,27 +2,6 @@
 
 {% set installs = grains.cfg_base.installs %}
 
-{#
-We get the following error on ubuntu 16.04:
-    UnicodeDecodeError: 'utf8' codec can't decode byte 0xbd in position 21: invalid start byte
-The following LANG settings fixes this problen in a docker container:
-    docker run -e LANG=C.UTF-8 -e LC_ALL=C.UTF-8 -it -v $(pwd):/vol xenial:salted bash
-So the preference is to set the locale in our base install state
-Copied below from https://docs.saltstack.com/en/latest/ref/states/all/salt.states.locale.html
-Possible only set the locale for specific OSes like ubuntu 16.04
-This has not been tested
-#}
-
-us_locale:
-  locale.present:
-    - name: en_US.UTF-8
-
-default_locale:
-  locale.system:
-    - name: en_US.UTF-8
-    - require:
-      - locale: us_locale
-
 {% if installs and 'firefox' in installs %}
 firefox:
   {% if grains.os_family == 'MacOS' %}


### PR DESCRIPTION
Fixes the us_locale conflict I introduced.
Restores the expected behavior of the pretty-swag version detection code.
Introduces logic in pretty-swag state to exclude pretty-swag install on Ubuntu 14.04.