### PR TITLE
Workaround for Salt bug 53570 in 2019.2.1

### DIFF
--- a/devkit/bootstrap-unix.sh
+++ b/devkit/bootstrap-unix.sh
@@ -114,6 +114,8 @@ echo Installing the devlopment kit
 saltdir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" &>/dev/null && pwd)
 ${sudo} ${tmpdir}/devkit/apply-state.sh ${debug}
 mv ${tmpdir} ${saltdir}
+# Temporary fix for demo, permanent fix TBD in salt states
+${sudo} chown -R $USER:$USER $HOME
 echo Development kit installation complete
 
 if command -v xdp-open >& /dev/null; then

--- a/devkit/bootstrap-unix.sh
+++ b/devkit/bootstrap-unix.sh
@@ -16,6 +16,15 @@ fi
 branch=
 debug=
 
+# Sets salt install-type to either "stable" or "stable <$salt-version>"
+# Workaround for https://github.com/saltstack/salt/issues/53570
+salt_version="2019.2.0"
+if [ $salt_version ]; then
+    install_type="stable ${salt_version}"
+else
+    install_type="stable"
+fi
+
 while getopts "b:d" opt; do
   case ${opt} in
     b ) branch="--branch ${OPTARG}"
@@ -90,7 +99,7 @@ else
 
     # -P Prevent failure by allowing the script to use pip as a dependency source
     # -X Do not start minion service
-    ${sudo} sh install_salt.sh -P -X
+    ${sudo} sh install_salt.sh -P -X ${install_type}
     echo SaltStack installation complete
 fi
 salt-call --version

--- a/devkit/states/microk8s/init.sls
+++ b/devkit/states/microk8s/init.sls
@@ -61,6 +61,10 @@ microk8s:
     {% else %}
     - name:     snap install microk8s --classic
     {% endif %}
+  group.present:
+    - name:     microk8s
+    - addusers:
+      -         {{ grains.realuser }}
   {% endif %}
 
   {% if grains.cfg_microk8s.debug.enable %}


### PR DESCRIPTION
Allows specifying Salt version in UNIX bootstrap script